### PR TITLE
Add spacing parameter to cad.text() for spacing control

### DIFF
--- a/src/primitives/cad_2d.lua
+++ b/src/primitives/cad_2d.lua
@@ -284,20 +284,22 @@ end
   style = depending on the font, usually "Bold","Italic", etc. default normal
   h_aling = horizontal alignment, Possible values are "left", "center" and "right". Default is "left".
   v_valign = vertical alignment for the text. Possible values are "top", "center", "baseline" and "bottom". Default is "baseline".
+  spacing = spacing between characters. Default is 1.
 
 --]]
 ------------------------------------------------------------------------------------
 
 local scad_text = [[
 translate([$X,$Y,$Z])
-text("$TEXT", size=$H, font="$FONT", halign="$HALIGN", valign="$VALIGN");
+text("$TEXT", size=$H, font="$FONT", halign="$HALIGN", valign="$VALIGN", spacing=$SPACING);
 ]]
-function cad.text(x, y, z, text, height, font, style, h_align, v_align)
+function cad.text(x, y, z, text, height, font, style, h_align, v_align, spacing)
   local height = height or 10
   local font = font or "Arial"
   local style = style and (":" .. style) or ""
   local h_align = h_align or "left"
   local v_align = v_align or "baseline"
+  local spacing = spacing or 1
   local t = {
     X = x,
     Y = y,
@@ -307,6 +309,7 @@ function cad.text(x, y, z, text, height, font, style, h_align, v_align)
     FONT = font .. style,
     HALIGN = h_align,
     VALIGN = v_align,
+    SPACING = spacing,
   }
   local obj = cad._helpers.cad_obj()
   cad._helpers.update_content_t(obj, scad_text, t)

--- a/tests/run_tests.lua
+++ b/tests/run_tests.lua
@@ -21,6 +21,7 @@ require("tests/test_sign")
 require("tests/test_simple")
 require("tests/test_sphere")
 require("tests/test_square")
+require("tests/test_text")
 require("tests/test_vector_cross")
 
 os.exit(luaunit.LuaUnit.run())

--- a/tests/test_text.lua
+++ b/tests/test_text.lua
@@ -1,0 +1,70 @@
+--[[--================================================================================
+  Test file for text function
+--]]
+--================================================================================
+
+local luaunit = require("luaunit")
+require("luacad")
+
+TestText = {}
+
+function TestText:setUp()
+  -- Create temp directory if it doesn't exist
+  os.execute("mkdir -p tests/temp")
+end
+
+function TestText:testTextCreationWithDefaultSpacing()
+  -- Test creating text with default spacing (should output spacing=1)
+  local obj = text(0, 0, 0, "Hello")
+  obj:export("temp/test_text_default_spacing.scad")
+
+  local file = io.open("tests/temp/test_text_default_spacing.scad", "r")
+  luaunit.assertNotNil(file, "SCAD file for text was not created")
+  if file then
+    local content = file:read("*all")
+    file:close()
+    luaunit.assertStrContains(
+      content,
+      "text(",
+      "Text command not found in generated SCAD file"
+    )
+    luaunit.assertStrContains(
+      content,
+      "spacing=1",
+      "Default spacing parameter not found in generated SCAD file"
+    )
+    luaunit.assertStrContains(
+      content,
+      "Hello",
+      "Text content not found in generated SCAD file"
+    )
+  end
+end
+
+function TestText:testTextCreationWithCustomSpacing()
+  -- Test creating text with custom spacing
+  local obj = text(0, 0, 0, "Test", 10, "Arial", nil, "left", "baseline", 1.5)
+  obj:export("temp/test_text_custom_spacing.scad")
+
+  local file = io.open("tests/temp/test_text_custom_spacing.scad", "r")
+  luaunit.assertNotNil(file, "SCAD file for text was not created")
+  if file then
+    local content = file:read("*all")
+    file:close()
+    luaunit.assertStrContains(
+      content,
+      "text(",
+      "Text command not found in generated SCAD file"
+    )
+    luaunit.assertStrContains(
+      content,
+      "spacing=1.5",
+      "Custom spacing parameter not found in generated SCAD file"
+    )
+  end
+end
+
+-- Run all tests
+if not ... then
+  os.exit(luaunit.LuaUnit.run())
+end


### PR DESCRIPTION
I've been trying to use this project (which is incredible btw) for designing stuff and just noticed that I could not set custom character spacing for text. Hence, this PR includes the following:
- **cad.text()**: New optional parameter `spacing` (defaults to 1, which is also what [OpenCAD follows](https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Text))
- **OpenSCAD output**: Emits `spacing=$SPACING` in the generated `text()` call
- **Tests**: New `tests/test_text.lua` with coverage for default and custom spacing

## Usage
-- Default spacing (1)
text(0, 0, 0, "Hello")

-- Custom spacing
text(0, 0, 0, "Hello", 10, "Arial", nil, "left", "baseline", 1.5)
